### PR TITLE
1.4.6: Makes rotations use Quaternion.Lerp instead of Vector3.Lerp

### DIFF
--- a/Packages/com.createneptune.sdk/CHANGELOG.md
+++ b/Packages/com.createneptune.sdk/CHANGELOG.md
@@ -92,7 +92,7 @@
 
 ### 1.3.9
 
--Change MPAction.FadeObject to prioritiza CanvasGroups over other UI components
+-Change MPAction.FadeObject to prioritize CanvasGroups over other UI components
 
 ### 1.3.10
 
@@ -126,3 +126,7 @@
 
 -Added bool loaded to SaveDataSingleton.
 -Added SetDefaultValues() to SaveDataSingleton.
+
+### 1.4.6
+
+-Altered MPAction.RotateObject to use Quaternion.Lerp for shortest-path rotations instead of using Vector3.Lerp.

--- a/Packages/com.createneptune.sdk/Runtime/MPAction.cs
+++ b/Packages/com.createneptune.sdk/Runtime/MPAction.cs
@@ -78,9 +78,9 @@ namespace CreateNeptune
                 easedTime = GetEasedTime(easeType, counter / animationTime);
 
                 if (local)
-                    rotateObjectT.localRotation = Quaternion.Euler(Vector3.LerpUnclamped(startRotation, endRotation, easedTime));
+                    rotateObjectT.localRotation = Quaternion.Lerp(Quaternion.Euler(startRotation), Quaternion.Euler(endRotation), easedTime);
                 else
-                    rotateObjectT.rotation = Quaternion.Euler(Vector3.LerpUnclamped(startRotation, endRotation, easedTime));
+                    rotateObjectT.rotation = Quaternion.Lerp(Quaternion.Euler(startRotation), Quaternion.Euler(endRotation), easedTime);
 
                 yield return null;
             }

--- a/Packages/com.createneptune.sdk/package.json
+++ b/Packages/com.createneptune.sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.createneptune.sdk",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "displayName": "CreateNeptune SDK",
   "description": "Create Neptune tweening and animation package.",
   "unity": "2019.1",


### PR DESCRIPTION
For shortest-path rotations, guaranteed by Quaternion.Lerp.