### PR TITLE
Highlands 8536: Fixed Save Data reload data wipe

### DIFF
--- a/Packages/com.createneptune.sdk/CHANGELOG.md
+++ b/Packages/com.createneptune.sdk/CHANGELOG.md
@@ -171,3 +171,7 @@
 - Added the CNTime class that can be used instead of DateTime to offset the current time for testing
 - Added a custom editor for this to add easy shorthand time offsets
 - Slightly adjusted package description
+
+### 3.3.1
+
+- Fixed a bug where a SaveDataSingleton can be reinstantiated if you exit playmode in the middle of loading another scene

--- a/Packages/com.createneptune.sdk/Runtime/SaveDataSingleton.cs
+++ b/Packages/com.createneptune.sdk/Runtime/SaveDataSingleton.cs
@@ -54,8 +54,10 @@ namespace CreateNeptune
             {
                 gameObject.SetActive(false);
                 Destroy(gameObject);
+                
                 return;
             }
+            
             hasBeenInstantiated = true;
 
             // Ensures that our save data is using the intended default values for its fields.

--- a/Packages/com.createneptune.sdk/Runtime/SaveDataSingleton.cs
+++ b/Packages/com.createneptune.sdk/Runtime/SaveDataSingleton.cs
@@ -33,10 +33,33 @@ namespace CreateNeptune
         }
 
         /// <summary>
+        /// This bool is used to prevent the SaveDataSingleton from ever being reinstantiated,
+        /// even if this GameObject is destroyed.
+        /// 
+        /// This fixes a bug that can occur if we exit playmode in the middle of a scene load 
+        /// (which can clear save data).
+        /// </summary>
+        private static bool hasBeenInstantiated = false;
+
+        /// <summary>
         /// child classes should override this to have some some initial data before anything gets loaded. 
         /// </summary>
         protected override void OnSuccessfulAwake()
         {
+            // This checks if this singleton has ever been instantiated before.
+            // If it has, we destroy this instance and set the game object to inactive.
+            // This is to prevent the singleton from being instantiated again if it has already been instantiated.
+            // This is a bug that can occur if we exit playmode in the middle of a scene load (which can clear save data).
+            if (hasBeenInstantiated)
+            {
+                gameObject.SetActive(false);
+                Destroy(gameObject);
+                return;
+            }
+            hasBeenInstantiated = true;
+
+            // Ensures that our save data is using the intended default values for its fields.
+            // (This way, you only need to manage default values in one place, SetDefaultValues).
             SetDefaultValues();
         }
 

--- a/Packages/com.createneptune.sdk/package.json
+++ b/Packages/com.createneptune.sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.createneptune.sdk",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "displayName": "Create Neptune SDK",
   "description": "Create Neptune tweening, animation, and other utilities package.",
   "unity": "2019.1",


### PR DESCRIPTION
## Highlandia Ticket:
https://app.shortcut.com/highlands-community-charter-and-technical-schools/story/8536/editor-savedata-getting-cleared-nuked-if-exiting-app-in-the-middle-of-loading-a-game-from-the-map-needs-device-testing-to

## Details 
In Highlandia, it was possible for save data to get reinitialized if you exited playmode in the middle of loading a new scene. This fixes that problem directly (only allowing save data to get fully initialized once). 

## Testing
I would recommend testing in Highlands directly. You can copy and paste over your local Package code. I've tested it myself this way and it seems to resolve the issue fine without breaking anything else. 